### PR TITLE
[#117647629] Removed regex to validate the mongo URI. It failed to ca…

### DIFF
--- a/index.js
+++ b/index.js
@@ -299,7 +299,7 @@ module.exports = function GridFSStore (globalOpts) {
     }
 
     function _setURI() {
-        if (!globalOpts.uri || !_URIisValid(globalOpts.uri)) {
+        if (!globalOpts.uri) {
             globalOpts.uri = mongodburi.format({
                 username: globalOpts.username,
                 password: globalOpts.password,
@@ -358,12 +358,7 @@ module.exports = function GridFSStore (globalOpts) {
             globalOpts.bucket = bucket;
         }
     }
-
-    function _URIisValid(uri) {
-        var regex = /^(mongodb:\/{2})?((\w+?):(\S+?)@|:?@?)([\w._-]+?):(\d+)\/([\w_-]+?).{0,1}([\w_-]+?)$/g;
-        return regex.test(uri);
-    }
-
+    
     function _connectionBuilder(opts) {
 
         var db;


### PR DESCRIPTION
…tch certain features, such as replica sets in the URI, that causes it to default to localhost in many cases. It's fairly unnecessary since the mongo URI parsing lib will complain with any issues of a malformed URI during the parsing - potentially giving a better idea of what portion of the URI is invalid rather than any invalid (or in this case valid) URIs simply magically becoming localhost.
